### PR TITLE
Extending ipcReceive to allow receiving one-time events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-const ipcReceive = require('./ipcReceive');
+const { ipcReceive, ipcReceiveOnce } = require('./ipcReceive');
 const ipcSend = require('./ipcSend');
 
 module.exports = {
   ipcReceive,
+  ipcReceiveOnce,
   ipcSend
 }

--- a/src/ipcReceive.js
+++ b/src/ipcReceive.js
@@ -15,12 +15,20 @@ ipcReceive('SOME_EVENT_NAME', (payload) => {
 - David Revay
 **************************************************/
 let ipcReceive
+let ipcReceiveOnce
 
 if (process.type == 'renderer') {
     const { ipcRenderer } = require('electron');
 
     ipcReceive = (event, callback) => {
         ipcRenderer.on(event, (event, wrappedPayload) => {
+          const payload = wrappedPayload.isStringified ? JSON.parse(wrappedPayload.payload) : wrappedPayload.payload;
+          callback(payload);
+        })
+    }
+
+    ipcReceiveOnce = (event, callback) => {
+        ipcRenderer.once(event, (event, wrappedPayload) => {
           const payload = wrappedPayload.isStringified ? JSON.parse(wrappedPayload.payload) : wrappedPayload.payload;
           callback(payload);
         })
@@ -35,6 +43,13 @@ if (process.type == 'renderer') {
           callback(payload);
         })
     }
+
+    ipcReceiveOnce = (event, callback) => {
+        ipcMain.once(event, (event, wrappedPayload) => {
+          const payload = wrappedPayload.isStringified ? JSON.parse(wrappedPayload.payload) : wrappedPayload.payload;
+          callback(payload);
+        })
+    }
 }
 
-module.exports = ipcReceive;
+module.exports = { ipcReceive, ipcReceiveOnce };


### PR DESCRIPTION
I often find myself requiring the ability to receive one-time events. I believe that adding this feature would make an awesome addition to the package, while still keeping everything simple.

Here's a small example:
```javascript
{ ipcReceiveOnce } = require('electron-simple-ipc');

ipcReceiveOnce('ONE_TIME_EVENT', (payload) => {
  // This event will only be executed once.
});
```